### PR TITLE
fix:   将[key in string]: TyResultFull<T>;改为[key in `${typeof NOT_PREFIX}${T}`]: TyResultFull<T>;

### DIFF
--- a/src/ty.ts
+++ b/src/ty.ts
@@ -11,13 +11,21 @@ type TyResultFull<T extends string> = {
 } & {
   [key in T]: TyResultFull<T>;
 } & {
-  [key in string]: TyResultFull<T>;
+  // 否运算
+  [key in `${typeof NOT_PREFIX}${T}`]: TyResultFull<T>;
+} & {
+  // 可为空运算
+  [key in `${typeof OPTIONAL_PREFIX}${T}`]: TyResultFull<T>;
 };
 
 type TyResult<T extends string> = {
   [key in T]: TyResultFull<T>;
 } & {
-  [key in string]: TyResultFull<T>;
+  // 否运算
+  [key in `${typeof NOT_PREFIX}${T}`]: TyResultFull<T>;
+} & {
+  // 可为空运算
+  [key in `${typeof OPTIONAL_PREFIX}${T}`]: TyResultFull<T>;
 };
 
 type ProxyTarget = { parameters: any[]; typeFlags?: TypeFlag[]; typeMatcher?: TypeMatcher<TypeFlag> };


### PR DESCRIPTION


<img width="543" alt="SCR-20240411-knnv-2" src="https://github.com/liutaigang/type-yes/assets/6830233/62c6584c-c044-4622-a8e2-5acfc8cc089f">

↓

<img width="886" alt="SCR-20240411-kmyg" src="https://github.com/liutaigang/type-yes/assets/6830233/61270e39-2519-4a0b-a930-01ac282ac380">
